### PR TITLE
Design, Feat/선생님 마이페이지, mock api 연결

### DIFF
--- a/src/api/editProfile/editProfile.hooks.ts
+++ b/src/api/editProfile/editProfile.hooks.ts
@@ -1,0 +1,27 @@
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { MyPageResponseData } from '../../types/myPageType';
+import { EditProfileRequestData } from '../../types/editProfile';
+
+const editProfile = async (
+  profileData: EditProfileRequestData
+): Promise<MyPageResponseData> => {
+  const response = await axios.patch<MyPageResponseData>(
+    '/api/profile/me',
+    profileData
+  );
+  return response.data;
+};
+
+export const useEditProfileMutation = (
+  options?: UseMutationOptions<
+    MyPageResponseData,
+    Error,
+    EditProfileRequestData
+  >
+) => {
+  return useMutation({
+    mutationFn: editProfile,
+    ...options,
+  });
+};

--- a/src/components/auth/AuthInput.tsx
+++ b/src/components/auth/AuthInput.tsx
@@ -8,16 +8,25 @@ type TInputProps = Omit<React.ComponentPropsWithoutRef<'input'>, 'type'> & {
 };
 
 const AuthInput = forwardRef<HTMLInputElement, TInputProps>(
-  ({ label, children, className, ...rest }, ref) => {
+  ({ label, children, className, onBlur, ...rest }, ref) => {
     const [isFocused, setIsFocused] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
 
     const handleContainerClick = () => {
       inputRef.current?.focus();
     };
 
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (!containerRef.current?.contains(e.relatedTarget as Node)) {
+        setIsFocused(false);
+        onBlur?.(e);
+      }
+    };
+
     return (
       <div
+        ref={containerRef}
         className={twMerge(
           'flex w-full items-center justify-between rounded-[10px] border-0 px-[14px] py-[8px] outline-none ring-1 ring-inset',
           isFocused
@@ -42,7 +51,7 @@ const AuthInput = forwardRef<HTMLInputElement, TInputProps>(
             className
           )}
           onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
+          onBlur={handleBlur}
           {...rest}
         />
         {children}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -15,7 +15,7 @@ const Header = ({ title, rightElement }: HeaderProps) => {
   return (
     <header className='flex items-center justify-between border-b border-borderColor bg-white px-2 py-6'>
       <div className='flex items-center'>
-        <button onClick={() => navigate(-1)} className='mr-2'>
+        <button onClick={() => navigate(-1)} type='button' className='mr-2'>
           <img src={backIcon} alt='' />
         </button>
 

--- a/src/components/editProfile/ProfileImages.tsx
+++ b/src/components/editProfile/ProfileImages.tsx
@@ -14,35 +14,47 @@ import studentIcon12 from '../../assets/editProfile/student/studentIcon12.png';
 import teacherDefaultIcon from '../../assets/editProfile/teacher/teacherDefaultIcon.png';
 import teacherIcon2 from '../../assets/editProfile/teacher/teacherIcon2.png';
 import teacherIcon3 from '../../assets/editProfile/teacher/teacherIcon3.png';
+import { useEffect } from 'react';
 
 type ProfileImagesProps = {
   selectedIndex: number;
-  onImageSelect: (index: number) => void;
+  onImageSelect: (index: number, imageUrl: string) => void;
   userType: 'student' | 'teacher';
+  currentImageUrl: string;
+};
+
+export const profileImages = {
+  student: [
+    studentDefaultIcon,
+    studentIcon2,
+    studentIcon3,
+    studentIcon4,
+    studentIcon5,
+    studentIcon6,
+    studentIcon7,
+    studentIcon8,
+    studentIcon9,
+    studentIcon10,
+    studentIcon11,
+    studentIcon12,
+  ],
+  teacher: [teacherDefaultIcon, teacherIcon2, teacherIcon3],
 };
 
 const ProfileImages = ({
   selectedIndex,
   onImageSelect,
   userType,
+  currentImageUrl,
 }: ProfileImagesProps) => {
-  const profileImages = {
-    student: [
-      studentDefaultIcon,
-      studentIcon2,
-      studentIcon3,
-      studentIcon4,
-      studentIcon5,
-      studentIcon6,
-      studentIcon7,
-      studentIcon8,
-      studentIcon9,
-      studentIcon10,
-      studentIcon11,
-      studentIcon12,
-    ],
-    teacher: [teacherDefaultIcon, teacherIcon2, teacherIcon3],
-  };
+  useEffect(() => {
+    const currentIndex = profileImages[userType].findIndex(
+      (img) => img === currentImageUrl
+    );
+    if (currentIndex !== -1) {
+      onImageSelect(currentIndex, currentImageUrl);
+    }
+  }, []);
 
   return (
     <div className='flex max-w-[410px] flex-wrap justify-between gap-x-4 gap-y-5 self-center pb-9'>
@@ -58,7 +70,7 @@ const ProfileImages = ({
             src={img}
             alt={`${userType} 프로필 이미지${index + 1}`}
             className='h-[60px] w-[60px] rounded-full object-cover'
-            onClick={() => onImageSelect(index)}
+            onClick={() => onImageSelect(index, img)}
           />
         </div>
       ))}

--- a/src/components/editProfile/inputFields/CommonFields.tsx
+++ b/src/components/editProfile/inputFields/CommonFields.tsx
@@ -1,0 +1,25 @@
+import AuthInput from '../../../components/auth/AuthInput';
+import { ProfileInputFieldsProps } from '../../../types/editProfile';
+
+const ProfileCommonFields: React.FC<ProfileInputFieldsProps> = ({
+  register,
+  errors,
+}) => (
+  <>
+    <div className='flex flex-col items-start gap-1'>
+      <AuthInput
+        type='text'
+        label='닉네임'
+        placeholder='닉네임을 입력해주세요.'
+        {...register('nickname')}
+      />
+      {errors.nickname && (
+        <span className='text-sm text-errorTextColor'>
+          {errors.nickname.message}
+        </span>
+      )}
+    </div>
+  </>
+);
+
+export default ProfileCommonFields;

--- a/src/components/editProfile/inputFields/StudentProfileFields.tsx
+++ b/src/components/editProfile/inputFields/StudentProfileFields.tsx
@@ -1,0 +1,51 @@
+import AuthInput from '../../../components/auth/AuthInput';
+import { ProfileInputFieldsProps } from '../../../types/editProfile';
+
+const StudentProfileFields: React.FC<ProfileInputFieldsProps> = ({
+  register,
+  errors,
+}) => (
+  <>
+    <div className='flex flex-col items-start gap-1'>
+      <AuthInput
+        type='text'
+        label='상태 메세지'
+        placeholder='상태 메세지를 입력해주세요.'
+        {...register('description')}
+      />
+      {errors.description && (
+        <span className='text-sm text-errorTextColor'>
+          {errors.description.message}
+        </span>
+      )}
+    </div>
+    <div className='flex flex-col items-start gap-1'>
+      <AuthInput
+        type='text'
+        label='희망진로'
+        placeholder='희망진로를 입력해주세요.'
+        {...register('career_aspiration')}
+      />
+      {errors.career_aspiration && (
+        <span className='text-sm text-errorTextColor'>
+          {errors.career_aspiration.message}
+        </span>
+      )}
+    </div>
+    <div className='flex flex-col items-start gap-1'>
+      <AuthInput
+        type='text'
+        label='흥미'
+        placeholder='흥미를 입력해주세요.'
+        {...register('interest')}
+      />
+      {errors.interest && (
+        <span className='text-sm text-errorTextColor'>
+          {errors.interest.message}
+        </span>
+      )}
+    </div>
+  </>
+);
+
+export default StudentProfileFields;

--- a/src/components/editProfile/inputFields/TeacherProfileFields.tsx
+++ b/src/components/editProfile/inputFields/TeacherProfileFields.tsx
@@ -1,0 +1,51 @@
+import AuthInput from '../../../components/auth/AuthInput';
+import { ProfileInputFieldsProps } from '../../../types/editProfile';
+
+const TeacherProfileFields: React.FC<ProfileInputFieldsProps> = ({
+  register,
+  errors,
+}) => (
+  <>
+    <div className='flex flex-col items-start gap-1'>
+      <AuthInput
+        type='text'
+        label='소속 이름'
+        placeholder='소속 이름을 입력해주세요.'
+        {...register('organization_name')}
+      />
+      {errors.organization_name && (
+        <span className='text-sm text-errorTextColor'>
+          {errors.organization_name.message}
+        </span>
+      )}
+    </div>
+    <div className='flex flex-col items-start gap-1'>
+      <AuthInput
+        type='text'
+        label='소속 종류'
+        placeholder='소속 종류를 입력해주세요.'
+        {...register('organization_type')}
+      />
+      {errors.organization_type && (
+        <span className='text-sm text-errorTextColor'>
+          {errors.organization_type.message}
+        </span>
+      )}
+    </div>
+    <div className='flex flex-col items-start gap-1'>
+      <AuthInput
+        type='text'
+        label='직급'
+        placeholder='직급을 입력해주세요.'
+        {...register('organization_position')}
+      />
+      {errors.organization_position && (
+        <span className='text-sm text-errorTextColor'>
+          {errors.organization_position.message}
+        </span>
+      )}
+    </div>
+  </>
+);
+
+export default TeacherProfileFields;

--- a/src/components/myPage/StudentPage.tsx
+++ b/src/components/myPage/StudentPage.tsx
@@ -1,44 +1,19 @@
 import { editIcon } from '../../assets/assets';
-import studentDefaultIcon from '../../assets/editProfile/student/studentDefaultIcon.png';
-import postTestImg from '../../../src/assets/editProfile/postTestImg.png';
 import { Link } from 'react-router-dom';
+import { StudentMyPageResponse } from '../../types/myPageType.ts';
 
-const StudentPage = () => {
-  const profileInfo = {
-    nickName: '닉네임',
-    dream: '희망진로, 흥미',
-    text: '상태 메세지',
-    post: 2,
-    like: 10,
-    comment: 18,
-  };
+type StudentPageProps = {
+  userInfo: StudentMyPageResponse;
+  communityInfo: { label: string; value: number }[];
+};
 
-  const communityInfo = [
-    { label: '게시물', value: profileInfo.post },
-    { label: '좋아요', value: profileInfo.like },
-    { label: '작성 댓글', value: profileInfo.comment },
-  ];
-
-  const postImg = [
-    postTestImg,
-    postTestImg,
-    postTestImg,
-    postTestImg,
-    postTestImg,
-    postTestImg,
-    postTestImg,
-    postTestImg,
-    postTestImg,
-    postTestImg,
-    postTestImg,
-  ];
-
+const StudentPage = ({ userInfo, communityInfo }: StudentPageProps) => {
   return (
-    <div className='flex w-full flex-col items-center gap-9 px-8 py-12'>
-      <ul className='flex flex-col gap-2'>
+    <>
+      <ul className='flex flex-col items-center gap-2'>
         <li className='relative h-[92px] w-[92px] rounded-full'>
           <img
-            src={studentDefaultIcon}
+            src={userInfo.profile_image}
             alt='학생 기본 이미지'
             className='h-full w-full'
           />
@@ -50,19 +25,18 @@ const StudentPage = () => {
             />
           </Link>
         </li>
-
         <li className='flex flex-col items-center'>
           <p className='text-xl font-bold text-textMainColor'>
-            {profileInfo.nickName}
+            {userInfo.nickname}
           </p>
-          <p className='mb-2 text-captionColor'>{profileInfo.dream}</p>
+          <p className='mb-2 text-captionColor'>{`${userInfo.career_aspiration}, ${userInfo.interest}`}</p>
           <p className='text-[13px] font-medium text-textMainColor'>
-            {profileInfo.text}
+            {userInfo.description}
           </p>
         </li>
       </ul>
 
-      <ul className='flex items-center justify-center gap-5'>
+      <ul className='flex items-center justify-center gap-6'>
         {communityInfo.map((info, index) => (
           <li
             key={index}
@@ -78,18 +52,18 @@ const StudentPage = () => {
         ))}
       </ul>
 
-      <div className='flex w-[321px] flex-col gap-3'>
+      <div className='flex w-[360px] flex-col gap-3'>
         <p className='text-left text-xs font-medium text-captionColor'>
           내 게시글
         </p>
-        <div className='flex flex-wrap gap-[15px]'>
-          {postImg.map((img, index) => (
+        <div className='flex flex-wrap gap-[6px]'>
+          {userInfo.posts.map((post) => (
             <div
-              key={`img${index}`}
-              className='h-[97px] w-[97px] overflow-hidden border border-postBorderColor'
+              key={post.post_id}
+              className='h-[116px] w-[116px] overflow-hidden border border-postBorderColor'
             >
               <img
-                src={img}
+                src={post.post_image}
                 alt='게시글 이미지'
                 className='h-full w-full object-cover'
               />
@@ -97,7 +71,7 @@ const StudentPage = () => {
           ))}
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/components/myPage/TeacherPage.tsx
+++ b/src/components/myPage/TeacherPage.tsx
@@ -1,48 +1,78 @@
 import { Link } from 'react-router-dom';
 import { editIcon } from '../../assets/assets';
-import teacherDefaultIcon from '../../assets/editProfile/teacher/teacherDefaultIcon.png';
+import { TeacherMyPageResponse } from '../../types/myPageType.ts';
 
-const TeacherPage = () => {
-  const profileInfo = [
-    { label: '닉네임', value: '닉네임' },
-    { label: '소속 종류', value: '소속 종류' },
-    { label: '소속 이름', value: '소속 이름' },
-    { label: '직급', value: '직급' },
-  ];
+type TeacherPageProps = {
+  userInfo: TeacherMyPageResponse;
+  communityInfo: { label: string; value: number }[];
+};
 
+const TeacherPage = ({ userInfo, communityInfo }: TeacherPageProps) => {
   return (
-    <div className='flex w-full flex-col items-center gap-12 px-8 py-12'>
-      <div className='relative h-[92px] w-[92px] rounded-full'>
-        <img
-          src={teacherDefaultIcon}
-          alt='선생님 기본 이미지'
-          className='h-full w-full'
-        />
-        <Link to='/edit-profile'>
+    <>
+      <ul className='flex flex-col items-center gap-2'>
+        <li className='relative h-[92px] w-[92px] rounded-full'>
           <img
-            src={editIcon}
-            alt='프로필 수정 아이콘'
-            className='absolute bottom-0 right-0'
+            src={userInfo.profile_image}
+            alt='선생님 기본 이미지'
+            className='h-full w-full'
           />
-        </Link>
-      </div>
+          <Link to='/edit-profile'>
+            <img
+              src={editIcon}
+              alt='프로필 수정 아이콘'
+              className='absolute bottom-0 right-0'
+            />
+          </Link>
+        </li>
 
-      <ul className='flex min-w-[361px] flex-col gap-9'>
-        {profileInfo.map((info, index) => (
+        <li className='flex flex-col items-center'>
+          <p className='text-xl font-bold text-textMainColor'>
+            {userInfo.nickname}
+          </p>
+          <p className='mb-2 text-captionColor'>{`${userInfo.organization_type}, ${userInfo.organization_name}`}</p>
+          <p className='text-[13px] font-medium text-textMainColor'>
+            {userInfo.organization_position}
+          </p>
+        </li>
+      </ul>
+
+      <ul className='flex items-center justify-center gap-6'>
+        {communityInfo.map((info, index) => (
           <li
             key={index}
-            className='flex h-[50px] w-full items-center rounded-[10px] px-5 py-[14px] shadow-profileInfoShadow'
+            className='flex h-[50px] w-[83px] flex-col items-center justify-center rounded-[10px] shadow-profileInfoShadow'
           >
-            <p className='w-[95px] text-[16px] font-semibold text-textMainColor'>
+            <p className='text-[13px] font-normal text-textMainColor'>
               {info.label}
             </p>
-            <p className='text-sm font-medium text-captionColor'>
+            <p className='text-[15px] font-bold text-profilePointTextColor'>
               {info.value}
             </p>
           </li>
         ))}
       </ul>
-    </div>
+
+      <div className='flex w-[360px] flex-col gap-3'>
+        <p className='text-left text-xs font-medium text-captionColor'>
+          협업 게시글
+        </p>
+        <div className='flex flex-wrap gap-[6px]'>
+          {userInfo.posts.map((post) => (
+            <div
+              key={post.post_id}
+              className='h-[116px] w-[116px] overflow-hidden border border-postBorderColor'
+            >
+              <img
+                src={post.post_image}
+                alt='게시글 이미지'
+                className='h-full w-full object-cover'
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,5 +1,7 @@
 import { setupWorker } from 'msw/browser';
 import { handlers } from './handlers';
+import { myPageHandlers } from './myPageHandlers';
 
-export const worker = setupWorker(...handlers);
+export const worker = setupWorker(...handlers, ...myPageHandlers);
+
 worker.start();

--- a/src/mocks/editProfileHandlers.ts
+++ b/src/mocks/editProfileHandlers.ts
@@ -1,0 +1,106 @@
+import { http, HttpResponse } from 'msw';
+import { EditProfileRequestData } from '../types/editProfile';
+
+export const editProfileHandlers = [
+  http.patch('/api/profile/me', async ({ request }) => {
+    const data = await request.json();
+
+    if (!data || typeof data !== 'object') {
+      return HttpResponse.json(
+        {
+          success: false,
+          message: '유효하지 않은 요청 데이터입니다.',
+          error: 'INVALID_DATA',
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!('role' in data)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          message: 'role 필드가 누락되었습니다.',
+          error: 'MISSING_ROLE',
+        },
+        { status: 400 }
+      );
+    }
+
+    // 학생 데이터 검증 및 업데이트
+    if (data.role === 'student') {
+      const requiredFields: (keyof EditProfileRequestData)[] = [
+        'nickname',
+        'profile_image',
+        'career_aspiration',
+        'interest',
+        'description',
+      ];
+
+      const missingFields = requiredFields.filter((field) => !data[field]);
+      if (missingFields.length > 0) {
+        return HttpResponse.json(
+          {
+            success: false,
+            message: `필수 정보가 누락되었습니다: ${missingFields.join(', ')}`,
+            error: 'MISSING_FIELDS',
+          },
+          { status: 400 }
+        );
+      }
+
+      // 성공적인 업데이트 응답 (모의 DB 업데이트 로직 추가 가능)
+      return HttpResponse.json(
+        {
+          success: true,
+          message: '학생 프로필이 성공적으로 업데이트되었습니다.',
+          data,
+        },
+        { status: 200 }
+      );
+    }
+
+    // 선생 데이터 검증 및 업데이트
+    if (data.role === 'teacher') {
+      const requiredFields: (keyof EditProfileRequestData)[] = [
+        'nickname',
+        'profile_image',
+        'organization_name',
+        'organization_type',
+        'organization_position',
+      ];
+
+      const missingFields = requiredFields.filter((field) => !data[field]);
+      if (missingFields.length > 0) {
+        return HttpResponse.json(
+          {
+            success: false,
+            message: `필수 정보가 누락되었습니다: ${missingFields.join(', ')}`,
+            error: 'MISSING_FIELDS',
+          },
+          { status: 400 }
+        );
+      }
+
+      // 성공적인 업데이트 응답
+      return HttpResponse.json(
+        {
+          success: true,
+          message: '선생 프로필이 성공적으로 업데이트되었습니다.',
+          data,
+        },
+        { status: 200 }
+      );
+    }
+
+    // 지원되지 않는 역할 처리
+    return HttpResponse.json(
+      {
+        success: false,
+        message: '지원되지 않는 역할(role)입니다.',
+        error: 'INVALID_ROLE',
+      },
+      { status: 400 }
+    );
+  }),
+];

--- a/src/mocks/myPageHandlers.ts
+++ b/src/mocks/myPageHandlers.ts
@@ -1,0 +1,190 @@
+import { http, HttpResponse } from 'msw';
+import {
+  MyPageResponseData,
+  StudentMyPageResponse,
+  TeacherMyPageResponse,
+} from '../types/myPageType';
+import { EditProfileRequestData } from '../types/editProfile';
+import postTestImg from '../assets/editProfile/postTestImg.png';
+import studentDefaultIcon from '../assets/editProfile/student/studentDefaultIcon.png';
+import teacherDefaultIcon from '../assets/editProfile/teacher/teacherDefaultIcon.png';
+
+const MOCK_STUDENT_PROFILE: StudentMyPageResponse = {
+  role: 'student',
+  nickname: '닉네임',
+  profile_image: studentDefaultIcon, // 임시 이미지
+  school: '학교',
+  grade: '학년',
+  career_aspiration: '희망 진로',
+  interest: '흥미',
+  description: '상태 메세지',
+  post_count: 2,
+  like_count: 10,
+  comment_count: 18,
+  posts: [
+    {
+      post_id: 'POST001',
+      post_image: postTestImg, // 임시 이미지
+    },
+    {
+      post_id: 'POST002',
+      post_image: postTestImg, // 임시 이미지
+    },
+    {
+      post_id: 'POST003',
+      post_image: postTestImg, // 임시 이미지
+    },
+    {
+      post_id: 'POST004',
+      post_image: postTestImg, // 임시 이미지
+    },
+    {
+      post_id: 'POST005',
+      post_image: postTestImg, // 임시 이미지
+    },
+  ],
+};
+
+const MOCK_TEACHER_PROFILE: TeacherMyPageResponse = {
+  role: 'teacher',
+  nickname: '닉네임',
+  profile_image: teacherDefaultIcon, // 임시 이미지
+  organization_name: '소속 이름',
+  organization_type: '소속 종류',
+  organization_position: '직급',
+  post_count: 5,
+  like_count: 20,
+  comment_count: 45,
+  posts: [
+    {
+      post_id: 'POST101',
+      post_image: postTestImg, // 임시 이미지
+    },
+    {
+      post_id: 'POST102',
+      post_image: postTestImg, // 임시 이미지
+    },
+  ],
+};
+
+export const myPageHandlers = [
+  http.get('/api/profile/me', async () => {
+    const role = 'student';
+    // const role = 'teacher';
+
+    const profile: MyPageResponseData =
+      role === 'student' ? MOCK_STUDENT_PROFILE : MOCK_TEACHER_PROFILE;
+
+    return HttpResponse.json(
+      {
+        success: true,
+        message: '마이페이지 데이터가 성공적으로 반환되었습니다.',
+        data: profile,
+      },
+      { status: 200 }
+    );
+  }),
+
+  http.patch('/api/profile/me', async ({ request }) => {
+    const data = await request.json();
+    console.log('Received data:', data); // 디버깅을 위한 로그
+
+    if (!data || typeof data !== 'object') {
+      return HttpResponse.json(
+        {
+          success: false,
+          message: '유효하지 않은 요청 데이터입니다.',
+          error: 'INVALID_DATA',
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!('role' in data)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          message: 'role 필드가 누락되었습니다.',
+          error: 'MISSING_ROLE',
+        },
+        { status: 400 }
+      );
+    }
+
+    // 학생 데이터 검증 및 업데이트
+    if (data.role === 'student') {
+      const requiredFields: (keyof EditProfileRequestData)[] = [
+        'nickname',
+        'profile_image',
+        'career_aspiration',
+        'interest',
+        'description',
+      ];
+
+      const missingFields = requiredFields.filter((field) => !data[field]);
+      if (missingFields.length > 0) {
+        return HttpResponse.json(
+          {
+            success: false,
+            message: `필수 정보가 누락되었습니다: ${missingFields.join(', ')}`,
+            error: 'MISSING_FIELDS',
+          },
+          { status: 400 }
+        );
+      }
+
+      // 성공적인 업데이트 응답 (모의 DB 업데이트 로직 추가 가능)
+      return HttpResponse.json(
+        {
+          success: true,
+          message: '학생 프로필이 성공적으로 업데이트되었습니다.',
+          data,
+        },
+        { status: 200 }
+      );
+    }
+
+    // 선생 데이터 검증 및 업데이트
+    if (data.role === 'teacher') {
+      const requiredFields: (keyof EditProfileRequestData)[] = [
+        'nickname',
+        'profile_image',
+        'organization_name',
+        'organization_type',
+        'organization_position',
+      ];
+
+      const missingFields = requiredFields.filter((field) => !data[field]);
+      if (missingFields.length > 0) {
+        return HttpResponse.json(
+          {
+            success: false,
+            message: `필수 정보가 누락되었습니다: ${missingFields.join(', ')}`,
+            error: 'MISSING_FIELDS',
+          },
+          { status: 400 }
+        );
+      }
+
+      // 성공적인 업데이트 응답
+      return HttpResponse.json(
+        {
+          success: true,
+          message: '선생 프로필이 성공적으로 업데이트되었습니다.',
+          data,
+        },
+        { status: 200 }
+      );
+    }
+
+    // 지원되지 않는 역할 처리
+    return HttpResponse.json(
+      {
+        success: false,
+        message: '지원되지 않는 역할(role)입니다.',
+        error: 'INVALID_ROLE',
+      },
+      { status: 400 }
+    );
+  }),
+];

--- a/src/pages/editProfile/editProfile.tsx
+++ b/src/pages/editProfile/editProfile.tsx
@@ -1,85 +1,183 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import AuthInput from '../../components/auth/AuthInput';
+import { FormProvider, useForm } from 'react-hook-form';
+import { z as zod } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Link, useNavigate } from 'react-router-dom';
 import Button from '../../components/common/Button';
 import Header from '../../components/common/Header';
-import ProfileImages from '../../components/editProfile/ProfileImages';
+import ProfileImages, {
+  profileImages,
+} from '../../components/editProfile/ProfileImages';
+import CommonFields from '../../components/editProfile/inputFields/CommonFields';
+import StudentProfileFields from '../../components/editProfile/inputFields/StudentProfileFields';
+// import TeacherProfileFields from '../../components/editProfile/inputFields/TeacherProfileFields';
+import axios from 'axios';
+import { useToast } from '../../hooks/useToast';
+import { useEffect, useState } from 'react';
+import { useEditProfileMutation } from '../../api/editProfile/editProfile.hooks';
+import { EditProfileRequestData } from '../../types/editProfile';
+import { useProfileStore } from '../../stores/editProfile/useProfileStore';
+import TeacherProfileFields from '../../components/editProfile/inputFields/TeacherProfileFields';
+
+const profileFormSchema = zod.discriminatedUnion('role', [
+  zod.object({
+    role: zod.literal('student'),
+    nickname: zod
+      .string()
+      .min(2, { message: '닉네임은 최소 2글자 이상이어야 합니다.' }),
+    description: zod
+      .string()
+      .min(1, { message: '상태 메세지는 필수 입력값입니다.' }),
+    career_aspiration: zod
+      .string()
+      .min(1, { message: '희망 진로는 필수 입력값입니다.' }),
+    interest: zod.string().min(1, { message: '흥미는 필수 입력값입니다.' }),
+  }),
+  zod.object({
+    role: zod.literal('teacher'),
+    nickname: zod
+      .string()
+      .min(2, { message: '닉네임은 최소 2글자 이상이어야 합니다.' }),
+    organization_name: zod
+      .string()
+      .min(1, { message: '소속 종류는 필수 입력값입니다.' }),
+    organization_type: zod
+      .string()
+      .min(1, { message: '소속 이름은 필수 입력값입니다.' }),
+    organization_position: zod
+      .string()
+      .min(1, { message: '직급는 필수 입력값입니다.' }),
+  }),
+]);
 
 const EditProfile = () => {
+  const { userInfo, updateProfile } = useProfileStore();
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  const [selectedImageUrl, setSelectedImageUrl] = useState('');
+  const { showToast } = useToast();
+  const navigate = useNavigate();
 
-  const handleImageSelect = (index: number) => {
-    setSelectedImageIndex(selectedImageIndex === index ? -1 : index);
+  // const role =
+  //   (sessionStorage.getItem('role') as 'student' | 'teacher') || undefined;
+
+  //? 임시 사용 변수
+  const role = userInfo?.role || 'student';
+
+  useEffect(() => {
+    if (!userInfo) {
+      showToast('로그인 후 이용바랍니다.');
+      navigate('/login');
+    } else {
+      const currentImageUrl = userInfo.profile_image;
+      if (currentImageUrl && profileImages[role]) {
+        const imageIndex = profileImages[role].findIndex(
+          (img) => img === currentImageUrl
+        );
+        setSelectedImageIndex(imageIndex !== -1 ? imageIndex : 0);
+        setSelectedImageUrl(currentImageUrl);
+      }
+    }
+  }, [userInfo, role]);
+
+  const form = useForm<EditProfileRequestData>({
+    resolver: zodResolver(profileFormSchema),
+    defaultValues: {
+      role: role,
+      nickname: '',
+      profile_image: '',
+      description: '',
+      career_aspiration: '',
+      interest: '',
+      organization_name: '',
+      organization_type: '',
+      organization_position: '',
+    },
+    mode: 'onChange',
+  });
+
+  const {
+    register,
+    formState: { errors },
+  } = form;
+
+  const editProfileMutation = useEditProfileMutation({
+    onSuccess: (data) => {
+      updateProfile(data);
+      showToast('프로필이 성공적으로 업데이트되었습니다.');
+      navigate('/my-page');
+    },
+    onError: (error) => {
+      if (axios.isAxiosError(error) && error.response) {
+        const { message } = error.response.data;
+        showToast(`업데이트 실패: ${message}`);
+      } else {
+        console.error('프로필 업데이트 중 오류 발생:', error);
+        showToast('프로필 업데이트 중 오류가 발생했습니다.');
+      }
+    },
+  });
+
+  const handleImageSelect = (index: number, imageUrl: string) => {
+    setSelectedImageIndex(index);
+    setSelectedImageUrl(imageUrl);
   };
 
+  const handleInvalid = () => {
+    showToast('모든 필드를 채워주세요.');
+  };
+
+  const handleEditProfile = (data: EditProfileRequestData) => {
+    const profileData: EditProfileRequestData = {
+      ...data,
+      profile_image: selectedImageUrl,
+    };
+
+    editProfileMutation.mutate(profileData);
+    updateProfile(profileData);
+  };
+
+  if (!userInfo) {
+    return null;
+  }
+
   return (
-    <div className='flex h-full flex-col'>
-      <Header title='프로필 수정' />
-      <div className='flex h-full w-full flex-col justify-between overflow-y-auto px-4 pb-12 pt-9'>
-        <div className='flex flex-col'>
+    <FormProvider {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleEditProfile, handleInvalid)}
+        className='flex h-full flex-col'
+        autoComplete='off'
+      >
+        <Header title='프로필 수정' />
+
+        <div className='flex h-full w-full flex-col overflow-y-scroll px-4 pb-12 pt-9'>
           <ProfileImages
             selectedIndex={selectedImageIndex}
             onImageSelect={handleImageSelect}
-            userType='student'
-            // userType='teacher'
+            userType={role}
+            currentImageUrl={userInfo.profile_image}
           />
-          <form className='flex flex-col gap-4 pb-2'>
-            {/* 공통 입력 필드 */}
-            <AuthInput
-              type='text'
-              label='닉네임'
-              placeholder='닉네임을 입력해주세요.'
-            />
 
-            {/* 학생 전용 입력 필드 */}
-            <>
-              <AuthInput
-                type='text'
-                label='상태 메세지'
-                placeholder='상태 메세지를 입력해주세요.'
-              />
-              <AuthInput
-                type='text'
-                label='희망진로'
-                placeholder='희망진로를 입력해주세요.'
-              />
-              <AuthInput
-                type='text'
-                label='흥미'
-                placeholder='흥미를 입력해주세요.'
-              />
-            </>
+          <div className='flex flex-col gap-4 pb-4'>
+            <CommonFields register={register} errors={errors} />
+            {role === 'student' && (
+              <StudentProfileFields register={register} errors={errors} />
+            )}
+            {role === 'teacher' && (
+              <TeacherProfileFields register={register} errors={errors} />
+            )}
+          </div>
 
-            {/* 교사 전용 입력 필드 */}
-            {/* <>
-              <AuthInput
-                type='text'
-                label='소속 종류'
-                placeholder='소속 종류를 입력해주세요.'
-              />
-              <AuthInput
-                type='text'
-                label='소속 이름'
-                placeholder='소속 이름을 입력해주세요.'
-              />
-              <AuthInput
-                type='text'
-                label='직급'
-                placeholder='직급을 입력해주세요.'
-              />
-            </> */}
-          </form>
-          <Link to='/change-profile' className='inline-block pb-4'>
+          <Link to='/change-profile' className='mb-8 w-fit'>
             <span className='text-sm font-medium text-primaryColor hover:text-primaryColor'>
               회원 정보 변경
             </span>
           </Link>
+
+          <Button variant='active' type='submit' className='mt-auto'>
+            변경 내용 저장
+          </Button>
         </div>
-        <Button variant='active' className='mt-auto'>
-          변경 내용 저장
-        </Button>
-      </div>
-    </div>
+      </form>
+    </FormProvider>
   );
 };
 

--- a/src/pages/myPage/myPage.tsx
+++ b/src/pages/myPage/myPage.tsx
@@ -1,12 +1,75 @@
-import StudentPage from '../../components/myPage/StudentPage';
-// import TeacherPage from '../../components/myPage/TeacherPage';
+import { useEffect, useState } from 'react';
+import {
+  StudentMyPageResponse,
+  TeacherMyPageResponse,
+} from '../../types/myPageType.ts';
+import StudentPage from '../../components/myPage/StudentPage.tsx';
+import TeacherPage from '../../components/myPage/TeacherPage.tsx';
+import { useProfileStore } from '../../stores/editProfile/useProfileStore.ts';
 
 const MyPage = () => {
+  const { userInfo, setUserInfo } = useProfileStore();
+  const [communityInfo, setCommunityInfo] = useState<
+    { label: string; value: number }[]
+  >([]);
+
+  useEffect(() => {
+    const fetchProfileData = async () => {
+      if (!userInfo) {
+        try {
+          const response = await fetch('/api/profile/me');
+          const result = await response.json();
+
+          if (result.success) {
+            setUserInfo(result.data);
+          }
+        } catch (error) {
+          console.error(
+            '프로필 데이터를 불러오는 중 오류가 발생했습니다:',
+            error
+          );
+        }
+      }
+    };
+
+    fetchProfileData();
+  }, [userInfo, setUserInfo]);
+
+  useEffect(() => {
+    if (userInfo) {
+      setCommunityInfo(
+        userInfo.role === 'student'
+          ? [
+              { label: '게시글', value: userInfo.post_count },
+              { label: '좋아요', value: userInfo.like_count },
+              { label: '작성 댓글', value: userInfo.comment_count },
+            ]
+          : [
+              { label: '협업 게시글', value: userInfo.post_count },
+              { label: '좋아요', value: userInfo.like_count },
+              { label: '작성 댓글', value: userInfo.comment_count },
+            ]
+      );
+    }
+  }, [userInfo]);
+
+  if (!userInfo) {
+    return null;
+  }
+
   return (
-    <div className='flex w-full flex-col items-center justify-center overflow-y-scroll pb-[62px]'>
-      {/* 로그인한 유저의 역할에 따라 컴포넌트 변경 */}
-      <StudentPage />
-      {/* <TeacherPage /> */}
+    <div className='m-auto flex w-full max-w-[360px] flex-col items-center gap-9 py-12'>
+      {userInfo.role === 'student' ? (
+        <StudentPage
+          userInfo={userInfo as StudentMyPageResponse}
+          communityInfo={communityInfo}
+        />
+      ) : (
+        <TeacherPage
+          userInfo={userInfo as TeacherMyPageResponse}
+          communityInfo={communityInfo}
+        />
+      )}
     </div>
   );
 };

--- a/src/stores/editProfile/useProfileStore.ts
+++ b/src/stores/editProfile/useProfileStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+import { MyPageResponseData } from '../../types/myPageType';
+import { EditProfileRequestData } from '../../types/editProfile';
+
+type ProfileStore = {
+  userInfo: MyPageResponseData | null;
+  setUserInfo: (info: MyPageResponseData) => void;
+  updateProfile: (data: Partial<EditProfileRequestData>) => void;
+};
+
+export const useProfileStore = create<ProfileStore>((set) => ({
+  userInfo: null,
+  setUserInfo: (info) => set({ userInfo: info }),
+  updateProfile: (data) =>
+    set((state) => {
+      if (!state.userInfo) return state;
+
+      const updatedInfo = {
+        ...state.userInfo,
+        ...data,
+        post_count: state.userInfo.post_count,
+        like_count: state.userInfo.like_count,
+        comment_count: state.userInfo.comment_count,
+        posts: state.userInfo.posts,
+      };
+
+      return {
+        userInfo: updatedInfo as MyPageResponseData,
+      };
+    }),
+}));

--- a/src/types/editProfile.ts
+++ b/src/types/editProfile.ts
@@ -1,0 +1,20 @@
+import { UseFormRegister, FieldErrors } from 'react-hook-form';
+
+export type EditProfileRequestData = {
+  role: 'student' | 'teacher';
+  nickname: string;
+  profile_image: string;
+  // 학생 전용 필드
+  career_aspiration?: string;
+  interest?: string;
+  description?: string;
+  // 교사 전용 필드
+  organization_name?: string;
+  organization_type?: string;
+  organization_position?: string;
+};
+
+export type ProfileInputFieldsProps = {
+  register: UseFormRegister<EditProfileRequestData>;
+  errors: FieldErrors<EditProfileRequestData>;
+};

--- a/src/types/myPageType.ts
+++ b/src/types/myPageType.ts
@@ -1,0 +1,37 @@
+// 공통된 마이페이지 응답 타입
+export type BaseMyPageResponse = {
+  role: 'student' | 'teacher';
+  nickname: string;
+  profile_image: string;
+  post_count: number;
+  like_count: number;
+  comment_count: number;
+  posts: Post[];
+};
+
+// 공통된 포스트 타입
+export type Post = {
+  post_id: string;
+  post_image: string;
+};
+
+// 학생 프로필 타입
+export type StudentMyPageResponse = BaseMyPageResponse & {
+  role: 'student';
+  school: string;
+  grade: string;
+  career_aspiration: string;
+  interest: string;
+  description: string;
+};
+
+// 선생님 프로필 타입
+export type TeacherMyPageResponse = BaseMyPageResponse & {
+  role: 'teacher';
+  organization_name: string;
+  organization_type: string;
+  organization_position: string;
+};
+
+// 통합 마이페이지 응답 타입
+export type MyPageResponseData = StudentMyPageResponse | TeacherMyPageResponse;


### PR DESCRIPTION
### 🌎Pull Request

> ### Title
>
> - [Design] 선생님 마이페이지 디자인 작업
> - [Feat] 마이 페이지, 프로필 수정 mock api 연결

> ### #️⃣연관되어 있는 이슈
>
> #35 , #39 

> ### PR Type
>
> - [x] FEAT :sparkles:: 새로운 기능 구현
> - [ ] ADD :bento:: 에셋 파일 추가
> - [ ] FIX :bug:: 버그 수정
> - [x] DESIGN :art:: CSS 등 사용자 UI 디자인 변경
> - [x] STYLE :lipstick:: 코드 포맷팅, 코드 수정이 없음
> - [ ] DOCS :memo:: 문서 추가 및 수정
> - [ ] REFACTOR :recycle:: 코드 리팩토링
> - [ ] TEST :clown_face:: 테스트 관련
> - [ ] DEPLOY :rocket:: 배포 관련
> - [ ] CONF :green_heart:: 빌드, 환경 설정
> - [x] CHORE :adhesive_bandage:: 기타 작업
> - [ ] RENAME :truck:: 파일 혹은 폴더명 수정 또는 이동
> - [ ] REMOVE :fire:: 파일 또는 코드 삭제

> ### Description
>
> - 선생님 마이페이지 스타일 작업(새로 제작 -> 피그마에 추가 완료)
> - 마이 페이지에서 학생과 선생님 컴포넌트 분리
> - 마이페이지와 프로필 수정 페이지에 mock api 생성 후 연결
> - 마이페이지에서 서버로 부터 받은 데이터 스토어에 저장하여 프로필 수정시 데이터 연동
> - 유저 정보 없을 시 프로필 수정 페이지 접근 시 로그인페이지로 강제 라우트


> ### Screenshot
>
> <img width="422" alt="스크린샷 2024-11-22 오후 10 56 43" src="https://github.com/user-attachments/assets/80cb6826-1ca7-436d-8d76-8422b38a3bde">

https://github.com/user-attachments/assets/06681c3c-cd87-4aa1-9989-4b7338a02df9


https://github.com/user-attachments/assets/cd50fe7b-07da-45a9-a283-a8ec5db2f590



> ### Discussion
>
> - 다음 작업으로 로그아웃 버튼 작업 예정입니다. 피그마에서 디자인 확인해주세요!
