### PR TITLE
Feat/마이 페이지 게시글 mock api 연결

### DIFF
--- a/src/api/myPage/myPage.hooks.ts
+++ b/src/api/myPage/myPage.hooks.ts
@@ -1,9 +1,9 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { MyPageResponseData } from '@/types/myPageType';
-import { fetchProfileAPI, fetchUserProfileAPI } from './myPageAPI';
+import { getMyProfileAPI, getUserProfileAPI } from './myPageAPI';
 
-export const useProfileQuery = (
+export const useProfileGetQuery = (
   userId?: string,
   options?: UseQueryOptions<MyPageResponseData, AxiosError, MyPageResponseData>
 ) => {
@@ -11,9 +11,9 @@ export const useProfileQuery = (
     queryKey: ['profile', userId],
     queryFn: () => {
       if (userId) {
-        return fetchUserProfileAPI(userId);
+        return getUserProfileAPI(userId);
       }
-      return fetchProfileAPI();
+      return getMyProfileAPI();
     },
     enabled: userId === undefined || Boolean(userId),
     ...options,

--- a/src/api/myPage/myPage.hooks.ts
+++ b/src/api/myPage/myPage.hooks.ts
@@ -1,14 +1,21 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { MyPageResponseData } from '@/types/myPageType';
-import { fetchProfileAPI } from './myPageAPI';
+import { fetchProfileAPI, fetchUserProfileAPI } from './myPageAPI';
 
 export const useProfileQuery = (
+  userId?: string,
   options?: UseQueryOptions<MyPageResponseData, AxiosError, MyPageResponseData>
 ) => {
   return useQuery({
-    queryKey: ['profile'],
-    queryFn: fetchProfileAPI,
+    queryKey: ['profile', userId],
+    queryFn: () => {
+      if (userId) {
+        return fetchUserProfileAPI(userId);
+      }
+      return fetchProfileAPI();
+    },
+    enabled: userId === undefined || Boolean(userId),
     ...options,
   });
 };

--- a/src/api/myPage/myPageAPI.ts
+++ b/src/api/myPage/myPageAPI.ts
@@ -7,8 +7,18 @@ type ProfileResponse = {
   data: MyPageResponseData;
 };
 
-export const fetchProfileAPI = async (): Promise<MyPageResponseData> => {
+export const fetchProfileAPI = async () => {
   const { data } = await axios.get<ProfileResponse>('/api/profile/me');
+
+  if (!data.success) {
+    throw new Error(data.message);
+  }
+
+  return data.data;
+};
+
+export const fetchUserProfileAPI = async (userId: string) => {
+  const { data } = await axios.get<ProfileResponse>(`/api/profile/${userId}`);
 
   if (!data.success) {
     throw new Error(data.message);

--- a/src/api/myPage/myPageAPI.ts
+++ b/src/api/myPage/myPageAPI.ts
@@ -7,7 +7,7 @@ type ProfileResponse = {
   data: MyPageResponseData;
 };
 
-export const fetchProfileAPI = async () => {
+export const getMyProfileAPI = async () => {
   const { data } = await axios.get<ProfileResponse>('/api/profile/me');
 
   if (!data.success) {
@@ -17,7 +17,7 @@ export const fetchProfileAPI = async () => {
   return data.data;
 };
 
-export const fetchUserProfileAPI = async (userId: string) => {
+export const getUserProfileAPI = async (userId: string) => {
   const { data } = await axios.get<ProfileResponse>(`/api/profile/${userId}`);
 
   if (!data.success) {

--- a/src/api/postDetail/postDetail.hooks.ts
+++ b/src/api/postDetail/postDetail.hooks.ts
@@ -1,0 +1,30 @@
+import {
+  UseInfiniteQueryOptions,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { PostDetailResponse } from '@/types/postDetail';
+import { getMyPostsAPI, getUserPostsAPI } from './postDetailAPI';
+
+export const usePostsInfiniteGetQuery = (
+  userId?: string,
+  options?: UseInfiniteQueryOptions<PostDetailResponse, AxiosError>
+) => {
+  return useInfiniteQuery({
+    queryKey: ['posts', userId],
+    queryFn: () => {
+      if (userId) {
+        return getUserPostsAPI(userId);
+      }
+      return getMyPostsAPI();
+    },
+    getNextPageParam: (lastPage) => {
+      console.log('Last Page for Pagination:', lastPage);
+      // if (!lastPage.next) return undefined;
+      // const nextPage = new URL(lastPage.next).searchParams.get('page');
+      // return nextPage ? Number(nextPage) : undefined;
+    },
+    initialPageParam: 1,
+    ...options,
+  });
+};

--- a/src/api/postDetail/postDetailAPI.ts
+++ b/src/api/postDetail/postDetailAPI.ts
@@ -1,0 +1,32 @@
+import { PostDetailResponse } from '@/types/postDetail';
+import axios from 'axios';
+
+type PostsApiResponse = {
+  success: boolean;
+  message: string;
+  data: PostDetailResponse;
+};
+
+export const getMyPostsAPI = async (page: number = 1) => {
+  const { data } = await axios.get<PostsApiResponse>('/api/posts/me', {
+    params: { page },
+  });
+
+  if (!data.success) {
+    throw new Error(data.message);
+  }
+
+  return data.data;
+};
+
+export const getUserPostsAPI = async (userId: string, page: number = 1) => {
+  const { data } = await axios.get<PostsApiResponse>(`/api/posts/${userId}`, {
+    params: { page },
+  });
+
+  if (!data.success) {
+    throw new Error(data.message);
+  }
+
+  return data.data;
+};

--- a/src/assets/assets.ts
+++ b/src/assets/assets.ts
@@ -2,7 +2,7 @@ import backIcon from './header/back.svg';
 import chatActiveIcon from './navBar/chat_active.svg';
 import chatBubbleIcon from './header/chat.svg';
 import chatDeleteIcon from './chat/chat_delete.svg';
-import chatPlusIcon from './chat/chat_plus.svg'
+import chatPlusIcon from './chat/chat_plus.svg';
 import toggleIcon from './myPage/toggleIcon.svg';
 import editIcon from './myPage/editIcon.svg';
 import logoutIcon from './myPage/logoutIcon.svg';
@@ -10,7 +10,6 @@ import googleLogo from './auth/google_login.svg';
 import homeActiveIcon from './navBar/home_active.svg';
 import iphone from './landing/iphone.svg';
 import kakaoLogo from './auth/kakao_logo.png';
-import logoutIcon from './myPage/logoutIcon.svg';
 import modalCloseIcon from './modal/modal_close.svg';
 import naverLogo from './auth/naver_logo.svg';
 import plusActiveIcon from './navBar/student/plus_active.svg';
@@ -19,7 +18,6 @@ import roleStudentUnActive from './roleSelect/role_student_unactive.svg';
 import roleTeacherActive from './roleSelect/role_teacher_active.svg';
 import roleTeacherUnActive from './roleSelect/role_teacher_unactive.svg';
 import thumbsUPIcon from './auth/thumbs_up.svg';
-import toggleIcon from './myPage/toggleIcon.svg';
 import userActiveIcon from './navBar/teacher/user_Active.svg';
 
 export {

--- a/src/components/editProfile/ProfileImages.tsx
+++ b/src/components/editProfile/ProfileImages.tsx
@@ -1,20 +1,6 @@
 import { twMerge } from 'tailwind-merge';
-import studentDefaultIcon from '@/assets/editProfile/student/studentDefaultIcon.png';
-import studentIcon2 from '@/assets/editProfile/student/studentIcon2.png';
-import studentIcon3 from '@/assets/editProfile/student/studentIcon3.png';
-import studentIcon4 from '@/assets/editProfile/student/studentIcon4.png';
-import studentIcon5 from '@/assets/editProfile/student/studentIcon5.png';
-import studentIcon6 from '@/assets/editProfile/student/studentIcon6.png';
-import studentIcon7 from '@/assets/editProfile/student/studentIcon7.png';
-import studentIcon8 from '@/assets/editProfile/student/studentIcon8.png';
-import studentIcon9 from '@/assets/editProfile/student/studentIcon9.png';
-import studentIcon10 from '@/assets/editProfile/student/studentIcon10.png';
-import studentIcon11 from '@/assets/editProfile/student/studentIcon11.png';
-import studentIcon12 from '@/assets/editProfile/student/studentIcon12.png';
-import teacherDefaultIcon from '@/assets/editProfile/teacher/teacherDefaultIcon.png';
-import teacherIcon2 from '@/assets/editProfile/teacher/teacherIcon2.png';
-import teacherIcon3 from '@/assets/editProfile/teacher/teacherIcon3.png';
 import { useEffect } from 'react';
+import { useProfileImages } from '@/hooks/useProfileImages';
 
 type ProfileImagesProps = {
   selectedIndex: number;
@@ -23,42 +9,26 @@ type ProfileImagesProps = {
   currentImageUrl: string;
 };
 
-export const profileImages = {
-  student: [
-    studentDefaultIcon,
-    studentIcon2,
-    studentIcon3,
-    studentIcon4,
-    studentIcon5,
-    studentIcon6,
-    studentIcon7,
-    studentIcon8,
-    studentIcon9,
-    studentIcon10,
-    studentIcon11,
-    studentIcon12,
-  ],
-  teacher: [teacherDefaultIcon, teacherIcon2, teacherIcon3],
-};
-
 const ProfileImages = ({
   selectedIndex,
   onImageSelect,
   userType,
   currentImageUrl,
 }: ProfileImagesProps) => {
+  const { images } = useProfileImages(userType, currentImageUrl, onImageSelect);
+
   useEffect(() => {
-    const currentIndex = profileImages[userType].findIndex(
-      (img) => img === currentImageUrl
-    );
-    if (currentIndex !== -1) {
-      onImageSelect(currentIndex, currentImageUrl);
+    if (currentImageUrl) {
+      const currentIndex = images.findIndex((img) => img === currentImageUrl);
+      if (currentIndex !== -1) {
+        onImageSelect(currentIndex, currentImageUrl);
+      }
     }
-  }, []);
+  }, [currentImageUrl]);
 
   return (
     <div className='flex max-w-[410px] flex-wrap justify-between gap-x-4 gap-y-5 self-center pb-9'>
-      {profileImages[userType].map((img, index) => (
+      {images.map((img, index) => (
         <div
           key={index}
           className={twMerge(

--- a/src/components/myPage/PostGrid.tsx
+++ b/src/components/myPage/PostGrid.tsx
@@ -1,25 +1,34 @@
 import { Post } from '@/types/myPageType';
+import { Link } from 'react-router-dom';
 
 type PostGridProps = {
-  posts: Post[];
   title: string;
+  posts: Post[];
+  userId?: string;
 };
 
-const PostGrid = ({ posts, title }: PostGridProps) => (
+const PostGrid = ({ posts, title, userId }: PostGridProps) => (
   <div className='flex w-[360px] flex-col gap-3'>
-    <p className='text-xs font-medium text-left text-captionColor'>{title}</p>
+    <p className='text-left text-xs font-medium text-captionColor'>{title}</p>
     <div className='flex flex-wrap gap-[6px]'>
       {posts.map((post) => (
-        <div
+        <Link
           key={post.post_id}
-          className='h-[116px] w-[116px] overflow-hidden border border-postBorderColor'
+          to={
+            userId
+              ? `/posts/${userId}?selected=${post.post_id}`
+              : `/posts?selected=${post.post_id}`
+          }
+          state={{ scrollToId: post.post_id }}
         >
-          <img
-            src={post.post_image}
-            alt='게시글 이미지'
-            className='object-cover w-full h-full'
-          />
-        </div>
+          <div className='h-[116px] w-[116px] overflow-hidden border border-postBorderColor'>
+            <img
+              src={post.post_image}
+              alt='게시글 이미지'
+              className='h-full w-full object-cover'
+            />
+          </div>
+        </Link>
       ))}
     </div>
   </div>

--- a/src/components/myPage/ProfileHeader.tsx
+++ b/src/components/myPage/ProfileHeader.tsx
@@ -5,6 +5,7 @@ type ProfileHeaderProps = {
   nickname: string;
   description: string;
   subDescription: string;
+  isOwnProfile: boolean;
 };
 
 const ProfileHeader = ({
@@ -12,11 +13,12 @@ const ProfileHeader = ({
   nickname,
   description,
   subDescription,
+  isOwnProfile,
 }: ProfileHeaderProps) => (
   <ul className='flex flex-col items-center gap-2'>
     <li className='relative h-[92px] w-[92px] rounded-full'>
-      <img src={profileImage} alt='프로필 이미지' className='h-full w-full' />
-      <ToggleButton />
+      <img src={profileImage} alt='프로필 이미지' className='w-full h-full' />
+      {isOwnProfile && <ToggleButton />}
     </li>
     <li className='flex flex-col items-center'>
       <p className='text-xl font-bold text-textMainColor'>{nickname}</p>

--- a/src/hooks/useGestureControl.ts
+++ b/src/hooks/useGestureControl.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
 
-interface UseGestureControlProps {
+type UseGestureControlProps = {
   onShowChange: (show: boolean) => void;
-}
+};
 
 export const useGestureControl = ({ onShowChange }: UseGestureControlProps) => {
   const [isDragging, setIsDragging] = useState(false);

--- a/src/hooks/useProfileImages.ts
+++ b/src/hooks/useProfileImages.ts
@@ -32,7 +32,7 @@ const images = {
     studentIcon12,
   ],
   teacher: [teacherDefaultIcon, teacherIcon2, teacherIcon3],
-} as const;
+};
 
 export const useProfileImages = (
   userType: UserType,

--- a/src/hooks/useProfileImages.ts
+++ b/src/hooks/useProfileImages.ts
@@ -1,0 +1,50 @@
+import studentDefaultIcon from '@/assets/editProfile/student/studentDefaultIcon.png';
+import studentIcon2 from '@/assets/editProfile/student/studentIcon2.png';
+import studentIcon3 from '@/assets/editProfile/student/studentIcon3.png';
+import studentIcon4 from '@/assets/editProfile/student/studentIcon4.png';
+import studentIcon5 from '@/assets/editProfile/student/studentIcon5.png';
+import studentIcon6 from '@/assets/editProfile/student/studentIcon6.png';
+import studentIcon7 from '@/assets/editProfile/student/studentIcon7.png';
+import studentIcon8 from '@/assets/editProfile/student/studentIcon8.png';
+import studentIcon9 from '@/assets/editProfile/student/studentIcon9.png';
+import studentIcon10 from '@/assets/editProfile/student/studentIcon10.png';
+import studentIcon11 from '@/assets/editProfile/student/studentIcon11.png';
+import studentIcon12 from '@/assets/editProfile/student/studentIcon12.png';
+import teacherDefaultIcon from '@/assets/editProfile/teacher/teacherDefaultIcon.png';
+import teacherIcon2 from '@/assets/editProfile/teacher/teacherIcon2.png';
+import teacherIcon3 from '@/assets/editProfile/teacher/teacherIcon3.png';
+
+type UserType = 'student' | 'teacher';
+
+const images = {
+  student: [
+    studentDefaultIcon,
+    studentIcon2,
+    studentIcon3,
+    studentIcon4,
+    studentIcon5,
+    studentIcon6,
+    studentIcon7,
+    studentIcon8,
+    studentIcon9,
+    studentIcon10,
+    studentIcon11,
+    studentIcon12,
+  ],
+  teacher: [teacherDefaultIcon, teacherIcon2, teacherIcon3],
+} as const;
+
+export const useProfileImages = (
+  userType: UserType,
+  currentImageUrl: string,
+  onImageSelect: (index: number, imageUrl: string) => void
+) => {
+  if (currentImageUrl && !images[userType].includes(currentImageUrl)) {
+    const defaultIndex = 0;
+    onImageSelect(defaultIndex, images[userType][defaultIndex]);
+  }
+
+  return {
+    images: images[userType],
+  };
+};

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,7 +1,12 @@
 import { setupWorker } from 'msw/browser';
 import { handlers } from './handlers';
 import { myPageHandlers } from './myPageHandlers';
+import { editProfileHandlers } from './editProfileHandlers';
 
-export const worker = setupWorker(...handlers, ...myPageHandlers);
+export const worker = setupWorker(
+  ...handlers,
+  ...myPageHandlers,
+  ...editProfileHandlers
+);
 
 worker.start();

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -2,11 +2,13 @@ import { setupWorker } from 'msw/browser';
 import { handlers } from './handlers';
 import { myPageHandlers } from './myPageHandlers';
 import { editProfileHandlers } from './editProfileHandlers';
+import { postDetailHandlers } from './postDetailHandlers';
 
 export const worker = setupWorker(
   ...handlers,
   ...myPageHandlers,
-  ...editProfileHandlers
+  ...editProfileHandlers,
+  ...postDetailHandlers
 );
 
 worker.start();

--- a/src/mocks/myPageHandlers.ts
+++ b/src/mocks/myPageHandlers.ts
@@ -4,7 +4,6 @@ import {
   StudentMyPageResponse,
   TeacherMyPageResponse,
 } from '@/types/myPageType';
-import { EditProfileRequestData } from '@/types/editProfile';
 import postTestImg from '@/assets/editProfile/postTestImg.png';
 import studentDefaultIcon from '@/assets/editProfile/student/studentDefaultIcon.png';
 import teacherDefaultIcon from '@/assets/editProfile/teacher/teacherDefaultIcon.png';
@@ -102,108 +101,6 @@ export const myPageHandlers = [
         data: profile,
       },
       { status: 200 }
-    );
-  }),
-
-  http.patch('/api/profile/me', async ({ request }) => {
-    const data = await request.json();
-
-    if (!data || typeof data !== 'object') {
-      return HttpResponse.json(
-        {
-          success: false,
-          message: '유효하지 않은 요청 데이터입니다.',
-          error: 'INVALID_DATA',
-        },
-        { status: 400 }
-      );
-    }
-
-    if (!('role' in data)) {
-      return HttpResponse.json(
-        {
-          success: false,
-          message: 'role 필드가 누락되었습니다.',
-          error: 'MISSING_ROLE',
-        },
-        { status: 400 }
-      );
-    }
-
-    // 학생 데이터 검증 및 업데이트
-    if (data.role === 'student') {
-      const requiredFields: (keyof EditProfileRequestData)[] = [
-        'nickname',
-        'profile_image',
-        'career_aspiration',
-        'interest',
-        'description',
-      ];
-
-      const missingFields = requiredFields.filter((field) => !data[field]);
-      if (missingFields.length > 0) {
-        return HttpResponse.json(
-          {
-            success: false,
-            message: `필수 정보가 누락되었습니다: ${missingFields.join(', ')}`,
-            error: 'MISSING_FIELDS',
-          },
-          { status: 400 }
-        );
-      }
-
-      // 성공적인 업데이트 응답 (모의 DB 업데이트 로직 추가 가능)
-      return HttpResponse.json(
-        {
-          success: true,
-          message: '학생 프로필이 성공적으로 업데이트되었습니다.',
-          data,
-        },
-        { status: 200 }
-      );
-    }
-
-    // 선생 데이터 검증 및 업데이트
-    if (data.role === 'teacher') {
-      const requiredFields: (keyof EditProfileRequestData)[] = [
-        'nickname',
-        'profile_image',
-        'organization_name',
-        'organization_type',
-        'organization_position',
-      ];
-
-      const missingFields = requiredFields.filter((field) => !data[field]);
-      if (missingFields.length > 0) {
-        return HttpResponse.json(
-          {
-            success: false,
-            message: `필수 정보가 누락되었습니다: ${missingFields.join(', ')}`,
-            error: 'MISSING_FIELDS',
-          },
-          { status: 400 }
-        );
-      }
-
-      // 성공적인 업데이트 응답
-      return HttpResponse.json(
-        {
-          success: true,
-          message: '선생 프로필이 성공적으로 업데이트되었습니다.',
-          data,
-        },
-        { status: 200 }
-      );
-    }
-
-    // 지원되지 않는 역할 처리
-    return HttpResponse.json(
-      {
-        success: false,
-        message: '지원되지 않는 역할(role)입니다.',
-        error: 'INVALID_ROLE',
-      },
-      { status: 400 }
     );
   }),
 ];

--- a/src/mocks/myPageHandlers.ts
+++ b/src/mocks/myPageHandlers.ts
@@ -11,6 +11,7 @@ import teacherDefaultIcon from '@/assets/editProfile/teacher/teacherDefaultIcon.
 
 const MOCK_STUDENT_PROFILE: StudentMyPageResponse = {
   role: 'student',
+  id: 'ID001',
   nickname: '닉네임',
   profile_image: studentDefaultIcon, // 임시 이미지
   school: '학교',
@@ -47,6 +48,7 @@ const MOCK_STUDENT_PROFILE: StudentMyPageResponse = {
 
 const MOCK_TEACHER_PROFILE: TeacherMyPageResponse = {
   role: 'teacher',
+  id: 'ID101',
   nickname: '닉네임',
   profile_image: teacherDefaultIcon, // 임시 이미지
   organization_name: '소속 이름',
@@ -79,6 +81,24 @@ export const myPageHandlers = [
       {
         success: true,
         message: '마이페이지 데이터가 성공적으로 반환되었습니다.',
+        data: profile,
+      },
+      { status: 200 }
+    );
+  }),
+
+  // 다른 사용자 프로필
+  http.get('/api/profile/:userId', async ({ params }) => {
+    const { userId } = params;
+    const profile: MyPageResponseData = {
+      ...MOCK_STUDENT_PROFILE,
+      id: userId as string,
+    };
+
+    return HttpResponse.json(
+      {
+        success: true,
+        message: '사용자 프로필 데이터가 성공적으로 반환되었습니다.',
         data: profile,
       },
       { status: 200 }

--- a/src/mocks/postDetailHandlers.ts
+++ b/src/mocks/postDetailHandlers.ts
@@ -1,0 +1,154 @@
+import { http, HttpResponse } from 'msw';
+import { PostDetailResponse } from '@/types/postDetail';
+// import { useParams } from 'react-router-dom';
+
+const MOCK_POSTS_1: PostDetailResponse = {
+  next: '/api/posts?page=2',
+  previous: null,
+  posts: [
+    {
+      post_id: 'POST001',
+      nickname: '학생태영',
+      profile_image: 'https://s3.image.com',
+      career_aspiration: '부자',
+      interest: '돈',
+      like_count: 10,
+      comment_count: 18,
+      image1: 's3.com',
+      image2: 's3.com',
+      image3: 's3.com',
+      content: '안녕하세요??',
+      teacher: {
+        nickname: '도인핑',
+        profile_image: 's3.com',
+      },
+      created_at: '2024-03-19T12:30:45.000Z',
+    },
+    {
+      post_id: 'POST002',
+      nickname: '학생태영',
+      profile_image: 'https://s3.image.com',
+      career_aspiration: '부자',
+      interest: '돈',
+      like_count: 10,
+      comment_count: 18,
+      image1: 's3.com',
+      image2: 's3.com',
+      image3: 's3.com',
+      content: '안녕하세요??',
+      teacher: {
+        nickname: '도인핑',
+        profile_image: 's3.com',
+      },
+      created_at: '2024-03-19T12:30:45.000Z',
+    },
+    {
+      post_id: 'POST003',
+      nickname: '학생태영',
+      profile_image: 'https://s3.image.com',
+      career_aspiration: '부자',
+      interest: '돈',
+      like_count: 10,
+      comment_count: 18,
+      image1: 's3.com',
+      image2: 's3.com',
+      image3: 's3.com',
+      content: '안녕하세요??',
+      teacher: {
+        nickname: '도인핑',
+        profile_image: 's3.com',
+      },
+      created_at: '2024-03-19T12:30:45.000Z',
+    },
+    {
+      post_id: 'POST004',
+      nickname: '학생태영',
+      profile_image: 'https://s3.image.com',
+      career_aspiration: '부자',
+      interest: '돈',
+      like_count: 10,
+      comment_count: 18,
+      image1: 's3.com',
+      image2: 's3.com',
+      image3: 's3.com',
+      content: '안녕하세요??',
+      teacher: {
+        nickname: '도인핑',
+        profile_image: 's3.com',
+      },
+      created_at: '2024-03-19T12:30:45.000Z',
+    },
+    {
+      post_id: 'POST005',
+      nickname: '학생태영',
+      profile_image: 'https://s3.image.com',
+      career_aspiration: '부자',
+      interest: '돈',
+      like_count: 10,
+      comment_count: 18,
+      image1: 's3.com',
+      image2: 's3.com',
+      image3: 's3.com',
+      content: '안녕하세요??',
+      teacher: {
+        nickname: '도인핑',
+        profile_image: 's3.com',
+      },
+      created_at: '2024-03-19T12:30:45.000Z',
+    },
+  ],
+};
+
+export const postDetailHandlers = [
+  // 내 게시글 목록 조회
+  http.get('/api/posts/me', async ({ request }) => {
+    const url = new URL(request.url);
+    const page = Number(url.searchParams.get('page')) || 1;
+    const myPosts = MOCK_POSTS_1;
+
+    return HttpResponse.json(
+      {
+        success: true,
+        message: '내 게시글 목록을 성공적으로 가져왔습니다.',
+        data: {
+          next: page < 3 ? `/api/posts?page=${page + 1}` : null,
+          previous: page > 1 ? `/api/posts?page=${page - 1}` : null,
+          posts: myPosts.posts,
+        },
+      },
+      { status: 200 }
+    );
+  }),
+
+  // 특정 사용자의 게시글 목록 조회
+  http.get('/api/posts/:userId', async ({ request }) => {
+    // const { userId } = useParams();
+    const url = new URL(request.url);
+    const page = Number(url.searchParams.get('page')) || 1;
+    const userPosts = MOCK_POSTS_1;
+
+    if (!userPosts) {
+      return HttpResponse.json(
+        {
+          success: false,
+          message: '사용자를 찾을 수 없습니다.',
+          error: 'USER_NOT_FOUND',
+        },
+        { status: 404 }
+      );
+    }
+
+    return HttpResponse.json(
+      {
+        success: true,
+        message: '사용자의 게시글 목록을 성공적으로 가져왔습니다.',
+        data: {
+          next: page < 3 ? `/api/posts?page=${page + 1}` : null,
+          previous: page > 1 ? `/api/posts?page=${page - 1}` : null,
+          posts: userPosts.posts,
+        },
+      },
+      { status: 200 }
+    );
+  }),
+];

--- a/src/pages/editProfile/editProfile.tsx
+++ b/src/pages/editProfile/editProfile.tsx
@@ -4,9 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '@/components/common/Button';
 import Header from '@/components/common/Header';
-import ProfileImages, {
-  profileImages,
-} from '@/components/editProfile/ProfileImages';
+import ProfileImages from '@/components/editProfile/ProfileImages';
 import CommonFields from '@/components/editProfile/inputFields/CommonFields';
 import StudentProfileFields from '@/components/editProfile/inputFields/StudentProfileFields';
 import TeacherProfileFields from '@/components/editProfile/inputFields/TeacherProfileFields';
@@ -65,17 +63,8 @@ const EditProfile = () => {
     if (!userInfo) {
       showToast('로그인 후 이용바랍니다.');
       navigate('/login');
-    } else {
-      const currentImageUrl = userInfo.profile_image;
-      if (currentImageUrl && profileImages[role]) {
-        const imageIndex = profileImages[role].findIndex(
-          (img) => img === currentImageUrl
-        );
-        setSelectedImageIndex(imageIndex !== -1 ? imageIndex : 0);
-        setSelectedImageUrl(currentImageUrl);
-      }
     }
-  }, [userInfo, role]);
+  }, [userInfo]);
 
   const form = useForm<EditProfileRequestData>({
     resolver: zodResolver(profileFormSchema),

--- a/src/pages/myPage/myPage.tsx
+++ b/src/pages/myPage/myPage.tsx
@@ -5,7 +5,7 @@ import { useToast } from '@/hooks/useToast';
 import ProfileHeader from '@/components/myPage/ProfileHeader';
 import CommunityInfo from '@/components/myPage/CommunityInfo';
 import PostGrid from '@/components/myPage/PostGrid';
-import { useProfileQuery } from '@/api/myPage/myPage.hooks';
+import { useProfileGetQuery } from '@/api/myPage/myPage.hooks';
 import { AxiosError } from 'axios';
 
 const MyPage = () => {
@@ -15,7 +15,7 @@ const MyPage = () => {
   const { userInfo, setUserInfo } = useProfileStore();
 
   // userId가 있으면 해당 유저의 프로필을, 없으면 내 프로필을 조회
-  const { data, error } = useProfileQuery(userId);
+  const { data, error } = useProfileGetQuery(userId);
   const isOwnProfile = !userId;
   const profileData = isOwnProfile ? userInfo : data;
 

--- a/src/pages/myPage/myPage.tsx
+++ b/src/pages/myPage/myPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useProfileStore } from '@/stores/editProfile/useProfileStore';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useToast } from '@/hooks/useToast';
 import ProfileHeader from '@/components/myPage/ProfileHeader';
 import CommunityInfo from '@/components/myPage/CommunityInfo';
@@ -9,13 +9,18 @@ import { useProfileQuery } from '@/api/myPage/myPage.hooks';
 import { AxiosError } from 'axios';
 
 const MyPage = () => {
+  const { userId } = useParams();
   const { showToast } = useToast();
   const navigate = useNavigate();
   const { userInfo, setUserInfo } = useProfileStore();
-  const { data, error } = useProfileQuery();
+
+  // userId가 있으면 해당 유저의 프로필을, 없으면 내 프로필을 조회
+  const { data, error } = useProfileQuery(userId);
+  const isOwnProfile = !userId;
+  const profileData = isOwnProfile ? userInfo : data;
 
   useEffect(() => {
-    if (data && !userInfo) {
+    if (data && !userInfo && isOwnProfile) {
       setUserInfo(data);
     }
     if (error instanceof AxiosError) {
@@ -28,34 +33,35 @@ const MyPage = () => {
         navigate('/login');
       }
     }
-  }, [data, error]);
+  }, [data, error, isOwnProfile, userInfo]);
 
-  if (!userInfo) {
+  if (!profileData) {
     return null;
   }
 
   return (
     <div className='m-auto flex w-full max-w-[360px] flex-col items-center gap-9 py-12'>
       <ProfileHeader
-        profileImage={userInfo.profile_image}
-        nickname={userInfo.nickname}
+        profileImage={profileData.profile_image}
+        nickname={profileData.nickname}
         description={
-          userInfo.role === 'student'
-            ? `${userInfo.career_aspiration}, ${userInfo.interest}`
-            : `${userInfo.organization_type}, ${userInfo.organization_name}`
+          profileData.role === 'student'
+            ? `${profileData.career_aspiration}, ${profileData.interest}`
+            : `${profileData.organization_type}, ${profileData.organization_name}`
         }
         subDescription={
-          userInfo.role === 'student'
-            ? userInfo.description
-            : userInfo.organization_position
+          profileData.role === 'student'
+            ? profileData.description
+            : profileData.organization_position
         }
+        isOwnProfile={isOwnProfile}
       />
 
-      <CommunityInfo userInfo={userInfo} />
+      <CommunityInfo userInfo={profileData} />
 
       <PostGrid
-        posts={userInfo.posts}
-        title={userInfo.role === 'student' ? '내 게시글' : '협업 게시글'}
+        posts={profileData.posts}
+        title={profileData.role === 'student' ? '내 게시글' : '협업 게시글'}
       />
     </div>
   );

--- a/src/pages/myPage/myPage.tsx
+++ b/src/pages/myPage/myPage.tsx
@@ -62,6 +62,7 @@ const MyPage = () => {
       <PostGrid
         posts={profileData.posts}
         title={profileData.role === 'student' ? '내 게시글' : '협업 게시글'}
+        userId={userId}
       />
     </div>
   );

--- a/src/pages/postDetail/postDetail.tsx
+++ b/src/pages/postDetail/postDetail.tsx
@@ -1,0 +1,15 @@
+import FeedPost from '@/components/main/FeedPost';
+
+const PostDetail = () => {
+  return (
+    <div className='flex w-full flex-col pb-[65px]'>
+      <FeedPost />
+      <FeedPost />
+      <FeedPost />
+      <FeedPost />
+      <FeedPost />
+    </div>
+  );
+};
+
+export default PostDetail;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -7,7 +7,6 @@ import TeacherLayout from '../layouts/teacherLayout';
 
 import Landing from '../pages/landing/landing';
 import LoadingPage from '../pages/loadingPage';
-import MyPost from '@/pages/myPost/myPost';
 
 const HomeFeedPage = lazy(() => import('../pages/main/homeFeedPage'));
 const ManagedStudentListPage = lazy(
@@ -15,6 +14,7 @@ const ManagedStudentListPage = lazy(
 );
 const LoginPage = lazy(() => import('../pages/auth/loginPage'));
 const MyPage = lazy(() => import('../pages/myPage/myPage'));
+const PostDetail = lazy(() => import('../pages/postDetail/postDetail'));
 const EditProfile = lazy(() => import('../pages/editProfile/editProfile'));
 const ChangeProfile = lazy(
   () => import('../pages/changeProfile/changeProfile')
@@ -140,7 +140,6 @@ const Router = () => {
               </Suspense>
             }
           />
-
           <Route
             path='/student/post'
             element={
@@ -168,21 +167,21 @@ const Router = () => {
                 </Suspense>
               }
             />
-            {/* 본인의 포스트 페이지*/}
+            {/* 본인의 게시글 상세 페이지*/}
             <Route
-              path='/my-post'
+              path='/posts'
               element={
                 <Suspense fallback={<LoadingPage />}>
-                  <MyPost />
+                  <PostDetail />
                 </Suspense>
               }
             />
-            {/* 다른 사용자의 포스트 페이지 */}
+            {/* 다른 사용자의 게시글 상세 페이지*/}
             <Route
-              path='/my-page/:userId'
+              path='/posts/:userId'
               element={
                 <Suspense fallback={<LoadingPage />}>
-                  <MyPage />
+                  <PostDetail />
                 </Suspense>
               }
             />

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -7,6 +7,7 @@ import TeacherLayout from '../layouts/teacherLayout';
 
 import Landing from '../pages/landing/landing';
 import LoadingPage from '../pages/loadingPage';
+import MyPost from '@/pages/myPost/myPost';
 
 const HomeFeedPage = lazy(() => import('../pages/main/homeFeedPage'));
 const ManagedStudentListPage = lazy(
@@ -149,8 +150,36 @@ const Router = () => {
             }
           />
           <Route element={<StudentLayout />}>
+            {/* 본인의 마이페이지 */}
             <Route
               path='/my-page'
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <MyPage />
+                </Suspense>
+              }
+            />
+            {/* 다른 사용자의 프로필 페이지 */}
+            <Route
+              path='/my-page/:userId'
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <MyPage />
+                </Suspense>
+              }
+            />
+            {/* 본인의 포스트 페이지*/}
+            <Route
+              path='/my-post'
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <MyPost />
+                </Suspense>
+              }
+            />
+            {/* 다른 사용자의 포스트 페이지 */}
+            <Route
+              path='/my-page/:userId'
               element={
                 <Suspense fallback={<LoadingPage />}>
                   <MyPage />

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -43,7 +43,7 @@ const TeacherChatRoomPage = lazy(
   () => import('../pages/chat/teacherChatRoomPage')
 );
 
-const CreatePostPage = lazy(() => import('../pages/post/createPostPage'));
+const CreatePostPage = lazy(() => import('../pages/posting/createPostPage'));
 
 const Router = () => {
   return (

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -44,7 +44,6 @@ const TeacherChatRoomPage = lazy(
 
 const CreatePostPage = lazy(() => import('../pages/post/createPostPage'));
 
-
 const Router = () => {
   return (
     <>
@@ -141,57 +140,58 @@ const Router = () => {
             }
           />
 
-        <Route
-          path='/student/post'
+          <Route
+            path='/student/post'
             element={
               <Suspense fallback={<LoadingPage />}>
                 <CreatePostPage />
               </Suspense>
             }
           />
-        <Route element={<StudentLayout />}>
-          <Route
-            path='/my-page'
-            element={
-              <Suspense fallback={<LoadingPage />}>
-                <MyPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path='/student-main'
-            element={
-              <Suspense fallback={<LoadingPage />}>
-                <HomeFeedPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path='/student/chats'
-            element={
-              <Suspense fallback={<LoadingPage />}>
-                <StudentChatListPage />
-              </Suspense>
-            }
-          />
-        </Route>
-        <Route element={<TeacherLayout />}>
-          <Route
-            path='/teacher-main'
-            element={
-              <Suspense fallback={<LoadingPage />}>
-                <ManagedStudentListPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path='/teacher/chats'
-            element={
-              <Suspense fallback={<LoadingPage />}>
-                <TeacherChatListPage />
-              </Suspense>
-            }
-          />
+          <Route element={<StudentLayout />}>
+            <Route
+              path='/my-page'
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <MyPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path='/student-main'
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <HomeFeedPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path='/student/chats'
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <StudentChatListPage />
+                </Suspense>
+              }
+            />
+          </Route>
+          <Route element={<TeacherLayout />}>
+            <Route
+              path='/teacher-main'
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <ManagedStudentListPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path='/teacher/chats'
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <TeacherChatListPage />
+                </Suspense>
+              }
+            />
+          </Route>
         </Route>
       </Routes>
     </>

--- a/src/types/myPageType.ts
+++ b/src/types/myPageType.ts
@@ -1,6 +1,7 @@
 // 공통된 마이페이지 응답 타입
 export type BaseMyPageResponse = {
   role: 'student' | 'teacher';
+  id: string;
   nickname: string;
   profile_image: string;
   post_count: number;

--- a/src/types/postDetail.ts
+++ b/src/types/postDetail.ts
@@ -1,0 +1,23 @@
+// 게시글 정보 응답 타입
+export type PostDetailResponse = {
+  next: string | null;
+  previous: string | null;
+  posts: Array<{
+    post_id: string;
+    nickname: string;
+    profile_image: string;
+    career_aspiration: string;
+    interest: string;
+    like_count: number;
+    comment_count: number;
+    image1: string;
+    image2: string | null;
+    image3: string | null;
+    content: string;
+    teacher: {
+      nickname: string;
+      profile_image: string;
+    };
+    created_at: string;
+  }>;
+};


### PR DESCRIPTION
### 🌎Pull Request

> ### Title
>
> - [Feat] 마이 페이지 게시글 mock api 연결

> ### #️⃣연관되어 있는 이슈
>
> #64 

> ### PR Type
>
> - [x] FEAT :sparkles:: 새로운 기능 구현
> - [ ] ADD :bento:: 에셋 파일 추가
> - [x] FIX :bug:: 버그 수정
> - [x] DESIGN :art:: CSS 등 사용자 UI 디자인 변경
> - [ ] STYLE :lipstick:: 코드 포맷팅, 코드 수정이 없음
> - [ ] DOCS :memo:: 문서 추가 및 수정
> - [x] REFACTOR :recycle:: 코드 리팩토링
> - [ ] TEST :clown_face:: 테스트 관련
> - [ ] DEPLOY :rocket:: 배포 관련
> - [ ] CONF :green_heart:: 빌드, 환경 설정
> - [ ] CHORE :adhesive_bandage:: 기타 작업
> - [ ] RENAME :truck:: 파일 혹은 폴더명 수정 또는 이동
> - [ ] REMOVE :fire:: 파일 또는 코드 삭제

> ### Description
>
> - assets.ts 파일에서 아이콘 중복 임포트 오류 해결
> - useGestureControl.ts 파일 타입 선언 통일
> - 학생/선생님에 따라 사용 가능한 프로필 이미지 목록을 제공하고 현재 선택된 이미지의 유효성을 검증(유효하지 않은 이미지일 경우 기본 이미지로 리셋)하는 훅 생성
> - 마이페이지 Query 이름 직관적으로 변경 및 아이디 값 추가
> - 다른 사용자 마이페이지 이동시 url에 유저 아이디가 있을 경우 수정 버튼 비활성화
> - 마이페이지 핸들러 중복 되는 부분 삭제
> - 게시글 정보 가져오는 mock api 생성

> ### Screenshot
>

https://github.com/user-attachments/assets/920d4021-538e-45b6-9731-81be29f9e297





> ### Discussion
>
> - 게시글 정보 가져오는 mock api 생성 하였으나 페이지값이 필요하고 다음 페이지 값을 가져오는데 mock으로 구현하기엔 복잡해보여서 pageDetail 페이지에 사용은 아직 하지않았습니다.
