### PR TITLE
Feat/회원정보 변경 api 생성 및 연결 2차

### DIFF
--- a/src/api/auth/changeProfile/editAccount/editAccount.hooks.ts
+++ b/src/api/auth/changeProfile/editAccount/editAccount.hooks.ts
@@ -1,0 +1,20 @@
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import {
+  EditAccountRequestParams,
+  EditAccountResponseDto,
+} from './editAccountType';
+import { editAccountAPI } from './editAccountAPI';
+
+export const useEditAccountMutation = (
+  options?: UseMutationOptions<
+    EditAccountResponseDto,
+    Error,
+    EditAccountRequestParams
+  >
+) => {
+  return useMutation({
+    mutationFn: editAccountAPI,
+    ...options,
+    throwOnError: true,
+  });
+};

--- a/src/api/auth/changeProfile/editAccount/editAccountAPI.ts
+++ b/src/api/auth/changeProfile/editAccount/editAccountAPI.ts
@@ -1,0 +1,15 @@
+import axiosInstance from '@/api/axiosInstance';
+import {
+  EditAccountRequestParams,
+  EditAccountResponseDto,
+} from './editAccountType';
+
+export const editAccountAPI = async (
+  userData: EditAccountRequestParams
+): Promise<EditAccountResponseDto> => {
+  const response = await axiosInstance.patch<EditAccountResponseDto>(
+    '/auth/update/info',
+    userData
+  );
+  return response.data;
+};

--- a/src/api/auth/changeProfile/editAccount/editAccountType.ts
+++ b/src/api/auth/changeProfile/editAccount/editAccountType.ts
@@ -1,0 +1,12 @@
+export type EditAccountRequestParams = {
+  role: 'student' | 'teacher' | undefined;
+  password: string;
+  password_confirm: string;
+  phone: string;
+  school?: string;
+  grade?: number;
+};
+
+export type EditAccountResponseDto = {
+  message: string;
+};

--- a/src/components/changeProfile/EditAccount.tsx
+++ b/src/components/changeProfile/EditAccount.tsx
@@ -1,53 +1,104 @@
-import { GradeSelector } from '../auth/GradeButton';
-import AuthInput from '../auth/AuthInput';
+import { FormProvider } from 'react-hook-form';
 import Button from '../common/Button';
-import { useState } from 'react';
+import AuthInput from '../auth/AuthInput';
+import { GradeSelector } from '../auth/GradeButton';
+import { useEditAccountForm } from '@/hooks/changeProfile/useEditAccountForm';
+import { useProfileStore } from '@/stores/editProfile/useProfileStore';
 
-type EditAccountProps = {
-  userType: 'student' | 'teacher';
-};
+const EditAccount = () => {
+  const { userInfo } = useProfileStore();
 
-const EditAccount = ({ userType }: EditAccountProps) => {
-  const [selectedGrade, setSelectedGrade] = useState<number>(1);
+  const {
+    form,
+    selectedGrade,
+    setSelectedGrade,
+    handleSubmit,
+    onSubmit,
+    register,
+    formState: { errors },
+  } = useEditAccountForm(userInfo?.role);
 
   return (
-    <div className='flex h-full flex-col justify-between gap-4 px-4 pb-[30px] pt-[38px]'>
-      <form className='flex flex-col gap-4'>
-        {/* 공통 입력 필드 */}
-        <AuthInput type='text' label='이메일' placeholder='example@email.com' />
-        <AuthInput
-          type='password'
-          label='패스워드'
-          placeholder='패스워드를 입력해주세요'
-        />
-        <AuthInput
-          type='password'
-          label='패스워드 확인'
-          placeholder='패스워드를 재입력해주세요.'
-        />
-        <AuthInput
-          type='number'
-          label='연락처'
-          placeholder='-없이 입력해주세요.'
-        />
-
-        {/* 학생 전용 입력 필드 */}
-        {userType === 'student' && (
-          <>
+    <FormProvider {...form}>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className='flex h-full flex-col justify-between px-4 pb-[30px] pt-[38px]'
+      >
+        <div className='flex h-full flex-col gap-4'>
+          <div>
             <AuthInput
-              type='text'
-              label='학교'
-              placeholder='학교 이름을 입력해주세요.'
+              type='password'
+              placeholder='패스워드를 입력해주세요.'
+              label='패스워드'
+              {...register('password')}
             />
-            <GradeSelector
-              selectedGrade={selectedGrade}
-              setSelectedGrade={setSelectedGrade}
+            {errors.password && (
+              <p className='mt-1 whitespace-pre text-sm text-errorTextColor'>
+                {errors.password.message}
+              </p>
+            )}
+            {!errors.password && (
+              <p className='mt-1 whitespace-pre text-xs text-captionColor'>
+                문자, 숫자, 특수문자(!@#$%^&*)포함 10~20자리 이내
+              </p>
+            )}
+          </div>
+          <div>
+            <AuthInput
+              type='password'
+              placeholder='패스워드를 재입력해주세요.'
+              label='패스워드 확인'
+              {...register('confirmPassword')}
             />
-          </>
-        )}
+            {errors.confirmPassword && (
+              <p className='mt-1 text-sm text-errorTextColor'>
+                {errors.confirmPassword.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <AuthInput
+              type='number'
+              placeholder='-없이 입력해주세요.'
+              label='연락처'
+              {...register('phone')}
+            />
+            {errors.phone && (
+              <p className='mt-1 text-sm text-errorTextColor'>
+                {errors.phone.message}
+              </p>
+            )}
+          </div>
+
+          {userInfo?.role === 'student' && (
+            <>
+              <div>
+                <AuthInput
+                  type='text'
+                  placeholder='학교 이름을 입력해주세요.'
+                  label='학교'
+                  {...register('school')}
+                />
+                {errors.school && (
+                  <p className='mt-1 text-sm text-errorTextColor'>
+                    {errors.school.message}
+                  </p>
+                )}
+              </div>
+              <GradeSelector
+                selectedGrade={selectedGrade}
+                setSelectedGrade={setSelectedGrade}
+              />
+            </>
+          )}
+        </div>
+
+        <Button type='submit' variant='active'>
+          변경 내용 저장
+        </Button>
       </form>
-      <Button variant='active'>변경 내용 저장</Button>
-    </div>
+    </FormProvider>
   );
 };
 

--- a/src/components/changeProfile/VerifyPassword.tsx
+++ b/src/components/changeProfile/VerifyPassword.tsx
@@ -1,78 +1,36 @@
-import { FormProvider, useForm } from 'react-hook-form';
-import { z as zod } from 'zod';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { FormProvider } from 'react-hook-form';
 import Button from '../common/Button';
-import { useVerifyPasswordMutation } from '@/api/auth/changeProfile/verifyPassword/verifyPassword.hooks';
 import AuthInput from '../auth/AuthInput';
-import { ApiErrorResponseDto } from '@/types/apiErrorType';
-import { useToast } from '@/hooks/useToast';
-import axios from 'axios';
-import { VerifyPasswordRequestParams } from '@/api/auth/changeProfile/verifyPassword/verifyPasswordType';
-
-const verifyPasswordSchema = zod.object({
-  password: zod.string().min(1, { message: '비밀번호를 입력해주세요.' }),
-});
+import { useVerifyPasswordForm } from '@/hooks/changeProfile/useVerifyPasswordForm';
 
 type VerifyPasswordProps = {
   onUserVerifyPassword: () => void;
 };
 
 const VerifyPassword = ({ onUserVerifyPassword }: VerifyPasswordProps) => {
-  const { showToast } = useToast();
-
-  const form = useForm<VerifyPasswordRequestParams>({
-    resolver: zodResolver(verifyPasswordSchema),
-    defaultValues: {
-      password: '',
-    },
-    mode: 'onChange',
-  });
-
   const {
+    form,
     register,
-    handleSubmit,
     formState: { errors },
-  } = form;
-
-  const { mutate: verifyPasswordMutation, isPending } =
-    useVerifyPasswordMutation({
-      onSuccess: () => {
-        onUserVerifyPassword();
-      },
-      onError: (error) => {
-        console.error('Login Error:', error);
-
-        if (axios.isAxiosError(error)) {
-          console.error('Axios Error Details:', {
-            response: error.response?.data,
-            status: error.response?.status,
-            headers: error.response?.headers,
-          });
-        }
-
-        const apiError = error as ApiErrorResponseDto;
-        const errorMessage =
-          apiError?.response?.data?.message ||
-          '비밀번호 확인에 실패하였습니다. 다시 시도해주세요.';
-        showToast(errorMessage);
-      },
-    });
+    handleVerifypassword,
+    isPending,
+  } = useVerifyPasswordForm();
 
   const onSubmit = () => {
-    const data = form.getValues();
-    verifyPasswordMutation(data);
+    handleVerifypassword();
+    onUserVerifyPassword();
   };
 
   return (
     <FormProvider {...form}>
       <form
-        onSubmit={handleSubmit(onSubmit)}
+        onSubmit={form.handleSubmit(onSubmit)}
         className='flex flex-col items-center gap-4 px-4 pt-[54px]'
       >
         <span className='text-[15px] font-medium text-textMainColor'>
           현재 비밀번호를 입력해주세요.
         </span>
-        <div className='flex flex-col w-full gap-2'>
+        <div className='flex w-full flex-col gap-2'>
           <AuthInput
             type='password'
             placeholder='비밀번호를 입력해주세요.'

--- a/src/components/changeProfile/VerifyPassword.tsx
+++ b/src/components/changeProfile/VerifyPassword.tsx
@@ -14,11 +14,10 @@ const VerifyPassword = ({ onUserVerifyPassword }: VerifyPasswordProps) => {
     formState: { errors },
     handleVerifypassword,
     isPending,
-  } = useVerifyPasswordForm();
+  } = useVerifyPasswordForm(onUserVerifyPassword);
 
   const onSubmit = () => {
     handleVerifypassword();
-    onUserVerifyPassword();
   };
 
   return (

--- a/src/hooks/changeProfile/useEditAccountForm.ts
+++ b/src/hooks/changeProfile/useEditAccountForm.ts
@@ -1,0 +1,87 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { useToast } from '../useToast';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { getEditSchemaByRole } from '@/schemas/editAccountSchemas';
+import { useEditAccountMutation } from '@/api/auth/changeProfile/editAccount/editAccount.hooks';
+import axios from 'axios';
+import { ApiErrorResponseDto } from '@/types/apiErrorType';
+import { EditAccountRequestParams } from '@/api/auth/changeProfile/editAccount/editAccountType';
+
+export const useEditAccountForm = (role: 'student' | 'teacher' | undefined) => {
+  const [selectedGrade, setSelectedGrade] = useState<number>(1);
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+
+  const form = useForm({
+    resolver: zodResolver(getEditSchemaByRole(role || '')),
+    defaultValues: {
+      password: '',
+      confirmPassword: '',
+      phone: '',
+      ...(role === 'student' && {
+        school: '',
+        grade: selectedGrade,
+      }),
+    },
+    mode: 'onSubmit',
+  });
+
+  const {
+    register,
+    formState: { errors },
+    getValues,
+    handleSubmit,
+  } = form;
+
+  const { mutate: editAccountMutation } = useEditAccountMutation({
+    onSuccess: (data) => {
+      console.log('회원 정보 변경 완료', data);
+      navigate('/my-page'), { replace: true };
+    },
+    onError: (error) => {
+      if (axios.isAxiosError(error)) {
+        console.error('Axios Error Details:', {
+          response: error.response?.data,
+          status: error.response?.status,
+          headers: error.response?.headers,
+        });
+      }
+
+      const apiError = error as ApiErrorResponseDto;
+      const errorMessage =
+        apiError?.response?.data?.message ||
+        '회원 정보 변경에 실패하였습니다. 다시 시도해주세요.';
+      showToast(errorMessage);
+    },
+  });
+
+  const onSubmit = () => {
+    const formData = form.getValues();
+
+    const editAccountData: EditAccountRequestParams = {
+      role: role as 'student' | 'teacher',
+      password: formData.password,
+      password_confirm: formData.confirmPassword,
+      phone: formData.phone,
+      ...(role === 'student' && {
+        school: formData.school,
+        grade: selectedGrade,
+      }),
+    };
+
+    editAccountMutation(editAccountData);
+  };
+
+  return {
+    form,
+    selectedGrade,
+    setSelectedGrade,
+    handleSubmit,
+    onSubmit,
+    register,
+    formState: { errors },
+    getValues,
+  };
+};

--- a/src/hooks/changeProfile/useVerifyPasswordForm.ts
+++ b/src/hooks/changeProfile/useVerifyPasswordForm.ts
@@ -11,7 +11,7 @@ const verifyPasswordSchema = zod.object({
   password: zod.string().min(1, { message: '비밀번호를 입력해주세요.' }),
 });
 
-export const useVerifyPasswordForm = () => {
+export const useVerifyPasswordForm = (onUserVerifyPassword: () => void) => {
   const { showToast } = useToast();
 
   const form = useForm<VerifyPasswordRequestParams>({
@@ -30,7 +30,9 @@ export const useVerifyPasswordForm = () => {
 
   const { mutate: verifyPasswordMutation, isPending } =
     useVerifyPasswordMutation({
-      onSuccess: () => {},
+      onSuccess: () => {
+        onUserVerifyPassword();
+      },
       onError: (error) => {
         if (axios.isAxiosError(error)) {
           console.error('Axios Error Details:', {

--- a/src/hooks/changeProfile/useVerifyPasswordForm.ts
+++ b/src/hooks/changeProfile/useVerifyPasswordForm.ts
@@ -1,0 +1,64 @@
+import { useForm } from 'react-hook-form';
+import { z as zod } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useVerifyPasswordMutation } from '@/api/auth/changeProfile/verifyPassword/verifyPassword.hooks';
+import { ApiErrorResponseDto } from '@/types/apiErrorType';
+import { useToast } from '@/hooks/useToast';
+import axios from 'axios';
+import { VerifyPasswordRequestParams } from '@/api/auth/changeProfile/verifyPassword/verifyPasswordType';
+
+const verifyPasswordSchema = zod.object({
+  password: zod.string().min(1, { message: '비밀번호를 입력해주세요.' }),
+});
+
+export const useVerifyPasswordForm = () => {
+  const { showToast } = useToast();
+
+  const form = useForm<VerifyPasswordRequestParams>({
+    resolver: zodResolver(verifyPasswordSchema),
+    defaultValues: {
+      password: '',
+    },
+    mode: 'onChange',
+  });
+
+  const {
+    register,
+    formState: { errors },
+    getValues,
+  } = form;
+
+  const { mutate: verifyPasswordMutation, isPending } =
+    useVerifyPasswordMutation({
+      onSuccess: () => {},
+      onError: (error) => {
+        if (axios.isAxiosError(error)) {
+          console.error('Axios Error Details:', {
+            response: error.response?.data,
+            status: error.response?.status,
+            headers: error.response?.headers,
+          });
+        }
+
+        const apiError = error as ApiErrorResponseDto;
+        const errorMessage =
+          apiError?.response?.data?.message ||
+          '비밀번호 확인에 실패하였습니다. 다시 시도해주세요.';
+        showToast(errorMessage);
+      },
+    });
+
+  const handleVerifypassword = () => {
+    const formData = form.getValues();
+    verifyPasswordMutation(formData);
+  };
+
+  return {
+    form,
+    register,
+    formState: { errors },
+    handleVerifypassword,
+    isPending,
+    getValues,
+  };
+};

--- a/src/pages/changeProfile/changeProfile.tsx
+++ b/src/pages/changeProfile/changeProfile.tsx
@@ -20,8 +20,7 @@ const ChangeProfile = () => {
       {!isVerified ? (
         <VerifyPassword onUserVerifyPassword={handleUserVerifyPassword} />
       ) : (
-        <EditAccount userType='student' />
-        // <EditAccount userType='teacher' />
+        <EditAccount />
       )}
     </div>
   );

--- a/src/pages/main/homeFeedPage.tsx
+++ b/src/pages/main/homeFeedPage.tsx
@@ -54,7 +54,7 @@ const HomeFeedPage = () => {
     return <ErrorPage error={error as Error} resetError={() => refetch()} />;
   }
 
-  if (!data || !data.pages) {
+  if (!data?.pages.length) {
     return <NotfoundPage />;
   }
 
@@ -76,7 +76,7 @@ const HomeFeedPage = () => {
       <MainHeader />
 
       {data.pages.map((page) =>
-        page.posts.map((post) => <FeedPost key={post.post_id} posts={post} />)
+        page.posts?.map((post) => <FeedPost key={post.post_id} posts={post} />)
       )}
 
       <div ref={observerRef} className='h-2' />
@@ -94,7 +94,7 @@ const HomeFeedPage = () => {
           >
             <div className='relative w-full rounded-t-[15px] bg-white md:w-[425px] lg:w-[425px]'>
               <button
-                className='absolute text-3xl right-4 top-1'
+                className='absolute right-4 top-1 text-3xl'
                 onClick={closeCommentModal}
               >
                 &times;

--- a/src/schemas/editAccountSchemas.ts
+++ b/src/schemas/editAccountSchemas.ts
@@ -1,0 +1,32 @@
+import { z as zod } from 'zod';
+
+// 기본 회원정보 변경 스키마
+export const baseEditSchema = zod.object({
+  password: zod
+    .string()
+    .regex(
+      /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*]).{10,20}$/,
+      '문자, 특수문자, 숫자가 혼합된 10~20자리의 비밀번호를 입력해주세요.'
+    )
+    .min(10, { message: '비밀번호는 10자 이상이어야 합니다.' })
+    .max(20, { message: '비밀번호는 20자 이하여야 합니다.' }),
+  confirmPassword: zod.string(),
+  phone: zod
+    .string()
+    .regex(/^0\d{9,10}$/, '전화번호 형식이 유효하지 않습니다.'),
+});
+
+// 학생용 회원정보 변경 스키마
+export const studentEditSchema = baseEditSchema.extend({
+  school: zod.string().min(1, { message: '학교명를 입력해주세요.' }),
+  grade: zod.number().min(1, { message: '학년은 1 이상이어야 합니다.' }),
+});
+
+// 역할에 따른 스키마 선택 함수
+export const getEditSchemaByRole = (role: string) => {
+  const schema = role === 'student' ? studentEditSchema : baseEditSchema;
+  return schema.refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  });
+};


### PR DESCRIPTION
### 🌎Pull Request

> ### Title
>
> - [Feat] 회원정보 변경 api 생성 및 연결 2차

> ### #️⃣연관되어 있는 이슈
>
> #99 

> ### PR Type
>
> - [x] FEAT :sparkles:: 새로운 기능 구현
> - [ ] ADD :bento:: 에셋 파일 추가
> - [x] FIX :bug:: 버그 수정
> - [ ] DESIGN :art:: CSS 등 사용자 UI 디자인 변경
> - [ ] STYLE :lipstick:: 코드 포맷팅, 코드 수정이 없음
> - [ ] DOCS :memo:: 문서 추가 및 수정
> - [x] REFACTOR :recycle:: 코드 리팩토링
> - [ ] TEST :clown_face:: 테스트 관련
> - [ ] DEPLOY :rocket:: 배포 관련
> - [ ] CONF :green_heart:: 빌드, 환경 설정
> - [ ] CHORE :adhesive_bandage:: 기타 작업
> - [ ] RENAME :truck:: 파일 혹은 폴더명 수정 또는 이동
> - [x] REMOVE :fire:: 파일 또는 코드 삭제

> ### Description
>
> - 비밀번호 검증 훅 따로 분리 & 계정 정보 변경 훅 따로 분리
> - 비번 검증, 계정 정보 변경 api 연결 로직 코드 작성
> - changeProfile 페이지에서 EditAccount 컴포넌트에 하드코딩으로 되어있던 프롭스 삭제
> - homeFeedPage 에서 응답으로 받는 데이더 없을 때 조건 수정
> - 계정 정보 변경 스키마 파일 따로 분리
> - 비번 틀렸는데 넘어가지는 오류 해결

> ### Screenshot
>

https://github.com/user-attachments/assets/b1f7088f-bbce-46ec-8bf9-773bf87a15c5


https://github.com/user-attachments/assets/7bbc6fb2-2ab5-4b59-95e0-1b527c3fbd3c


>
> ### Discussion
>
> - throwOnError: true 삭제 외 코드 통일 부분은 새 브랜치 파서 작업할 예정 입니다!
